### PR TITLE
feat: add L2CAP support

### DIFF
--- a/bt.h
+++ b/bt.h
@@ -139,6 +139,7 @@ int cb_l2cap_read(void *channel, uint8_t *buf, int maxLen);
 int cb_l2cap_write(void *channel, const uint8_t *data, int len);
 bool cb_l2cap_has_bytes_available(void *channel);
 bool cb_l2cap_has_space_available(void *channel);
+void cb_l2cap_schedule_streams(void *channel);
 void cb_l2cap_close(void *channel);
 void cb_pmgr_publish_l2cap_channel(void *pmgr, bool encryption);
 void cb_pmgr_unpublish_l2cap_channel(void *pmgr, uint16_t psm);

--- a/bt.h
+++ b/bt.h
@@ -132,6 +132,17 @@ bool cb_prph_can_send_write_without_rsp(void *prph);
 void cb_prph_read_rssi(void *prph);
 bool cb_prph_ancs_authorized(void *prph);
 
+// l2cap.m
+void cb_prph_open_l2cap_channel(void *prph, uint16_t psm);
+uint16_t cb_l2cap_psm(void *channel);
+int cb_l2cap_read(void *channel, uint8_t *buf, int maxLen);
+int cb_l2cap_write(void *channel, const uint8_t *data, int len);
+bool cb_l2cap_has_bytes_available(void *channel);
+bool cb_l2cap_has_space_available(void *channel);
+void cb_l2cap_close(void *channel);
+void cb_pmgr_publish_l2cap_channel(void *pmgr, bool encryption);
+void cb_pmgr_unpublish_l2cap_channel(void *pmgr, uint16_t psm);
+
 const char *cb_svc_uuid(void *svc);
 void *cb_svc_peripheral(void *svc);
 bool cb_svc_is_primary(void *svc);
@@ -213,6 +224,12 @@ void BTPeripheralManagerCentralDidUnsubscribe(void *pmgr, void *cent, void *chr)
 void BTPeripheralManagerIsReadyToUpdateSubscribers(void *pmgr);
 void BTPeripheralManagerDidReceiveReadRequest(void *pmgr, void *req);
 void BTPeripheralManagerDidReceiveWriteRequests(void *pmgr, struct obj_arr *oa);
+
+// cbhandlers.go (L2CAP)
+void BTPeripheralDidOpenL2CAPChannel(void *prph, void *channel, struct bt_error *err);
+void BTPeripheralManagerDidPublishL2CAPChannel(void *pmgr, uint16_t psm, struct bt_error *err);
+void BTPeripheralManagerDidUnpublishL2CAPChannel(void *pmgr, uint16_t psm, struct bt_error *err);
+void BTPeripheralManagerDidOpenL2CAPChannel(void *pmgr, void *channel, struct bt_error *err);
 
 extern dispatch_queue_t bt_queue;
 extern BTDlg *bt_dlg;

--- a/btdlg.m
+++ b/btdlg.m
@@ -326,6 +326,7 @@ didOpenL2CAPChannel:(CBL2CAPChannel *)channel
 {
     if (channel != nil) {
         [channel retain];
+        cb_l2cap_schedule_streams(channel);
     }
     struct bt_error err = nserror_to_bt_error(nserr);
     BTPeripheralDidOpenL2CAPChannel(prph, channel, &err);
@@ -490,6 +491,7 @@ didOpenL2CAPChannel:(CBL2CAPChannel *)channel
 {
     if (channel != nil) {
         [channel retain];
+        cb_l2cap_schedule_streams(channel);
     }
     struct bt_error err = nserror_to_bt_error(nserr);
     BTPeripheralManagerDidOpenL2CAPChannel(pmgr, channel, &err);

--- a/btdlg.m
+++ b/btdlg.m
@@ -316,6 +316,21 @@ didModifyServices:(NSArray<CBService *> *)invSvcs
     free(oa.objs);
 }
 
+/**
+ * Called when an L2CAP channel has been opened.
+ */
+- (void)
+    peripheral:(CBPeripheral *)prph
+didOpenL2CAPChannel:(CBL2CAPChannel *)channel
+         error:(NSError *)nserr
+{
+    if (channel != nil) {
+        [channel retain];
+    }
+    struct bt_error err = nserror_to_bt_error(nserr);
+    BTPeripheralDidOpenL2CAPChannel(prph, channel, &err);
+}
+
 
 /**
  * Called whenever the peripheral manager's state is updated.
@@ -439,6 +454,45 @@ didReceiveWriteRequests:(NSArray *)reqs
 
     BTPeripheralManagerDidReceiveWriteRequests(pmgr, &oa);
     free(oa.objs);
+}
+
+/**
+ * Called when an L2CAP channel has been published.
+ */
+- (void)
+peripheralManager:(CBPeripheralManager *)pmgr
+didPublishL2CAPChannel:(CBL2CAPPSM)psm
+             error:(NSError *)nserr
+{
+    struct bt_error err = nserror_to_bt_error(nserr);
+    BTPeripheralManagerDidPublishL2CAPChannel(pmgr, psm, &err);
+}
+
+/**
+ * Called when an L2CAP channel has been unpublished.
+ */
+- (void)
+peripheralManager:(CBPeripheralManager *)pmgr
+didUnpublishL2CAPChannel:(CBL2CAPPSM)psm
+               error:(NSError *)nserr
+{
+    struct bt_error err = nserror_to_bt_error(nserr);
+    BTPeripheralManagerDidUnpublishL2CAPChannel(pmgr, psm, &err);
+}
+
+/**
+ * Called when a remote device opens an L2CAP channel to this peripheral.
+ */
+- (void)
+peripheralManager:(CBPeripheralManager *)pmgr
+didOpenL2CAPChannel:(CBL2CAPChannel *)channel
+          error:(NSError *)nserr
+{
+    if (channel != nil) {
+        [channel retain];
+    }
+    struct bt_error err = nserror_to_bt_error(nserr);
+    BTPeripheralManagerDidOpenL2CAPChannel(pmgr, channel, &err);
 }
 
 @end

--- a/cbhandlers.go
+++ b/cbhandlers.go
@@ -404,3 +404,51 @@ func BTPeripheralManagerDidReceiveWriteRequests(pmgr unsafe.Pointer, oa *C.struc
 		dlg.DidReceiveWriteRequests(PeripheralManager{pmgr}, reqs)
 	}
 }
+
+//export BTPeripheralDidOpenL2CAPChannel
+func BTPeripheralDidOpenL2CAPChannel(prph unsafe.Pointer, channel unsafe.Pointer, err *C.struct_bt_error) {
+	nserr := btErrorToNSError(err)
+
+	btlog.Debugf("PeripheralDidOpenL2CAPChannel: prph=%v channel=%v err=%v", prph, channel, nserr)
+
+	dlg := findPeripheralDlg(prph)
+	if dlg != nil {
+		dlg.DidOpenL2CAPChannel(Peripheral{prph}, L2CAPChannel{channel}, nserr)
+	}
+}
+
+//export BTPeripheralManagerDidPublishL2CAPChannel
+func BTPeripheralManagerDidPublishL2CAPChannel(pmgr unsafe.Pointer, psm C.uint16_t, err *C.struct_bt_error) {
+	nserr := btErrorToNSError(err)
+
+	btlog.Debugf("PeripheralManagerDidPublishL2CAPChannel: pmgr=%v psm=%v err=%v", pmgr, psm, nserr)
+
+	dlg := findPeripheralManagerDlg(pmgr)
+	if dlg != nil {
+		dlg.DidPublishL2CAPChannel(PeripheralManager{pmgr}, uint16(psm), nserr)
+	}
+}
+
+//export BTPeripheralManagerDidUnpublishL2CAPChannel
+func BTPeripheralManagerDidUnpublishL2CAPChannel(pmgr unsafe.Pointer, psm C.uint16_t, err *C.struct_bt_error) {
+	nserr := btErrorToNSError(err)
+
+	btlog.Debugf("PeripheralManagerDidUnpublishL2CAPChannel: pmgr=%v psm=%v err=%v", pmgr, psm, nserr)
+
+	dlg := findPeripheralManagerDlg(pmgr)
+	if dlg != nil {
+		dlg.DidUnpublishL2CAPChannel(PeripheralManager{pmgr}, uint16(psm), nserr)
+	}
+}
+
+//export BTPeripheralManagerDidOpenL2CAPChannel
+func BTPeripheralManagerDidOpenL2CAPChannel(pmgr unsafe.Pointer, channel unsafe.Pointer, err *C.struct_bt_error) {
+	nserr := btErrorToNSError(err)
+
+	btlog.Debugf("PeripheralManagerDidOpenL2CAPChannel: pmgr=%v channel=%v err=%v", pmgr, channel, nserr)
+
+	dlg := findPeripheralManagerDlg(pmgr)
+	if dlg != nil {
+		dlg.DidOpenL2CAPChannel(PeripheralManager{pmgr}, L2CAPChannel{channel}, nserr)
+	}
+}

--- a/l2cap.m
+++ b/l2cap.m
@@ -1,0 +1,59 @@
+#import <Foundation/Foundation.h>
+#import <CoreBluetooth/CoreBluetooth.h>
+#import "bt.h"
+
+// l2cap.m: L2CAP Connection-Oriented Channel support (macOS 10.13+)
+
+void cb_prph_open_l2cap_channel(void *prph, uint16_t psm) {
+    CBPeripheral *p = (CBPeripheral *)prph;
+    [p openL2CAPChannel:(CBL2CAPPSM)psm];
+}
+
+uint16_t cb_l2cap_psm(void *channel) {
+    CBL2CAPChannel *ch = (CBL2CAPChannel *)channel;
+    return ch.PSM;
+}
+
+int cb_l2cap_read(void *channel, uint8_t *buf, int maxLen) {
+    CBL2CAPChannel *ch = (CBL2CAPChannel *)channel;
+    NSInputStream *stream = ch.inputStream;
+    if (![stream hasBytesAvailable]) {
+        return 0;
+    }
+    return (int)[stream read:buf maxLength:maxLen];
+}
+
+int cb_l2cap_write(void *channel, const uint8_t *data, int len) {
+    CBL2CAPChannel *ch = (CBL2CAPChannel *)channel;
+    NSOutputStream *stream = ch.outputStream;
+    if (![stream hasSpaceAvailable]) {
+        return 0;
+    }
+    return (int)[stream write:data maxLength:len];
+}
+
+bool cb_l2cap_has_bytes_available(void *channel) {
+    CBL2CAPChannel *ch = (CBL2CAPChannel *)channel;
+    return [ch.inputStream hasBytesAvailable];
+}
+
+bool cb_l2cap_has_space_available(void *channel) {
+    CBL2CAPChannel *ch = (CBL2CAPChannel *)channel;
+    return [ch.outputStream hasSpaceAvailable];
+}
+
+void cb_l2cap_close(void *channel) {
+    CBL2CAPChannel *ch = (CBL2CAPChannel *)channel;
+    [ch.inputStream close];
+    [ch.outputStream close];
+}
+
+void cb_pmgr_publish_l2cap_channel(void *pmgr, bool encryption) {
+    CBPeripheralManager *pm = (CBPeripheralManager *)pmgr;
+    [pm publishL2CAPChannelWithEncryption:encryption];
+}
+
+void cb_pmgr_unpublish_l2cap_channel(void *pmgr, uint16_t psm) {
+    CBPeripheralManager *pm = (CBPeripheralManager *)pmgr;
+    [pm unpublishL2CAPChannel:(CBL2CAPPSM)psm];
+}

--- a/l2cap.m
+++ b/l2cap.m
@@ -42,10 +42,23 @@ bool cb_l2cap_has_space_available(void *channel) {
     return [ch.outputStream hasSpaceAvailable];
 }
 
+void cb_l2cap_schedule_streams(void *channel) {
+    CBL2CAPChannel *ch = (CBL2CAPChannel *)channel;
+    NSRunLoop *rl = [NSRunLoop mainRunLoop];
+    [ch.inputStream scheduleInRunLoop:rl forMode:NSDefaultRunLoopMode];
+    [ch.outputStream scheduleInRunLoop:rl forMode:NSDefaultRunLoopMode];
+    [ch.inputStream open];
+    [ch.outputStream open];
+}
+
 void cb_l2cap_close(void *channel) {
     CBL2CAPChannel *ch = (CBL2CAPChannel *)channel;
+    NSRunLoop *rl = [NSRunLoop mainRunLoop];
     [ch.inputStream close];
     [ch.outputStream close];
+    [ch.inputStream removeFromRunLoop:rl forMode:NSDefaultRunLoopMode];
+    [ch.outputStream removeFromRunLoop:rl forMode:NSDefaultRunLoopMode];
+    [ch release];
 }
 
 void cb_pmgr_publish_l2cap_channel(void *pmgr, bool encryption) {

--- a/l2capchannel.go
+++ b/l2capchannel.go
@@ -1,0 +1,57 @@
+package cbgo
+
+/*
+// See cutil.go for C compiler flags.
+#import "bt.h"
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+// L2CAPChannel: https://developer.apple.com/documentation/corebluetooth/cbl2capchannel
+type L2CAPChannel struct {
+	ptr unsafe.Pointer
+}
+
+// PSM returns the channel's Protocol/Service Multiplexer identifier.
+// PSM: https://developer.apple.com/documentation/corebluetooth/cbl2capchannel/2880155-psm
+func (ch L2CAPChannel) PSM() uint16 {
+	return uint16(C.cb_l2cap_psm(ch.ptr))
+}
+
+// Read reads up to len(buf) bytes from the L2CAP channel's input stream.
+// Returns the number of bytes read. Returns 0 if no bytes are currently
+// available, or a negative value on error.
+func (ch L2CAPChannel) Read(buf []byte) int {
+	if len(buf) == 0 {
+		return 0
+	}
+	return int(C.cb_l2cap_read(ch.ptr, (*C.uint8_t)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+}
+
+// Write writes data to the L2CAP channel's output stream.
+// Returns the number of bytes written. Returns 0 if the stream has no space
+// available, or a negative value on error.
+func (ch L2CAPChannel) Write(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+	return int(C.cb_l2cap_write(ch.ptr, (*C.uint8_t)(unsafe.Pointer(&data[0])), C.int(len(data))))
+}
+
+// HasBytesAvailable returns true if the input stream has bytes available to read.
+func (ch L2CAPChannel) HasBytesAvailable() bool {
+	return bool(C.cb_l2cap_has_bytes_available(ch.ptr))
+}
+
+// HasSpaceAvailable returns true if the output stream has space available for writing.
+func (ch L2CAPChannel) HasSpaceAvailable() bool {
+	return bool(C.cb_l2cap_has_space_available(ch.ptr))
+}
+
+// Close closes the L2CAP channel's input and output streams.
+func (ch L2CAPChannel) Close() {
+	C.cb_l2cap_close(ch.ptr)
+}

--- a/peripheral.go
+++ b/peripheral.go
@@ -152,3 +152,8 @@ func (p Peripheral) CanSendWriteWithoutResponse() bool {
 func (p Peripheral) ReadRSSI() {
 	C.cb_prph_read_rssi(p.ptr)
 }
+
+// OpenL2CAPChannel: https://developer.apple.com/documentation/corebluetooth/cbperipheral/2880157-openl2capchannel
+func (p Peripheral) OpenL2CAPChannel(psm uint16) {
+	C.cb_prph_open_l2cap_channel(p.ptr, C.uint16_t(psm))
+}

--- a/peripheraldelegate.go
+++ b/peripheraldelegate.go
@@ -40,6 +40,9 @@ type PeripheralDelegate interface {
 
 	// DidModifyServices: https://developer.apple.com/documentation/corebluetooth/cbperipheraldelegate/1518865-peripheral
 	DidModifyServices(prph Peripheral, invSvcs []Service)
+
+	// DidOpenL2CAPChannel: https://developer.apple.com/documentation/corebluetooth/cbperipheraldelegate/2874038-peripheral
+	DidOpenL2CAPChannel(prph Peripheral, channel L2CAPChannel, err error)
 }
 
 // PeripheralDelegateBase implements the PeripheralDelegate interface with stub
@@ -73,4 +76,6 @@ func (b *PeripheralDelegateBase) DidReadRSSI(prph Peripheral, rssi int, err erro
 func (b *PeripheralDelegateBase) DidUpdateName(prph Peripheral) {
 }
 func (b *PeripheralDelegateBase) DidModifyServices(prph Peripheral, invSvcs []Service) {
+}
+func (b *PeripheralDelegateBase) DidOpenL2CAPChannel(prph Peripheral, channel L2CAPChannel, err error) {
 }

--- a/peripheralmanager.go
+++ b/peripheralmanager.go
@@ -153,3 +153,13 @@ func (pm PeripheralManager) RespondToRequest(req ATTRequest, result ATTError) {
 func (pm PeripheralManager) SetDesiredConnectionLatency(latency PeripheralManagerConnectionLatency, central Central) {
 	C.cb_pmgr_set_conn_latency(pm.ptr, C.int(latency), central.ptr)
 }
+
+// PublishL2CAPChannel: https://developer.apple.com/documentation/corebluetooth/cbperipheralmanager/2880158-publishl2capchannel
+func (pm PeripheralManager) PublishL2CAPChannel(encryption bool) {
+	C.cb_pmgr_publish_l2cap_channel(pm.ptr, C.bool(encryption))
+}
+
+// UnpublishL2CAPChannel: https://developer.apple.com/documentation/corebluetooth/cbperipheralmanager/2880156-unpublishl2capchannel
+func (pm PeripheralManager) UnpublishL2CAPChannel(psm uint16) {
+	C.cb_pmgr_unpublish_l2cap_channel(pm.ptr, C.uint16_t(psm))
+}

--- a/peripheralmanagerdelegate.go
+++ b/peripheralmanagerdelegate.go
@@ -28,6 +28,15 @@ type PeripheralManagerDelegate interface {
 
 	// DidReceiveWriteRequests: https://developer.apple.com/documentation/corebluetooth/cbperipheralmanagerdelegate/1393315-peripheralmanager
 	DidReceiveWriteRequests(pmgr PeripheralManager, reqs []ATTRequest)
+
+	// DidPublishL2CAPChannel: https://developer.apple.com/documentation/corebluetooth/cbperipheralmanagerdelegate/2880171-peripheralmanager
+	DidPublishL2CAPChannel(pmgr PeripheralManager, psm uint16, err error)
+
+	// DidUnpublishL2CAPChannel: https://developer.apple.com/documentation/corebluetooth/cbperipheralmanagerdelegate/2880170-peripheralmanager
+	DidUnpublishL2CAPChannel(pmgr PeripheralManager, psm uint16, err error)
+
+	// DidOpenL2CAPChannel: https://developer.apple.com/documentation/corebluetooth/cbperipheralmanagerdelegate/2880172-peripheralmanager
+	DidOpenL2CAPChannel(pmgr PeripheralManager, channel L2CAPChannel, err error)
 }
 
 // PeripheralManagerDelegateBase implements the PeripheralManagerDelegate
@@ -53,4 +62,10 @@ func (b *PeripheralManagerDelegateBase) IsReadyToUpdateSubscribers(pmgr Peripher
 func (b *PeripheralManagerDelegateBase) DidReceiveReadRequest(pmgr PeripheralManager, req ATTRequest) {
 }
 func (b *PeripheralManagerDelegateBase) DidReceiveWriteRequests(pmgr PeripheralManager, reqs []ATTRequest) {
+}
+func (b *PeripheralManagerDelegateBase) DidPublishL2CAPChannel(pmgr PeripheralManager, psm uint16, err error) {
+}
+func (b *PeripheralManagerDelegateBase) DidUnpublishL2CAPChannel(pmgr PeripheralManager, psm uint16, err error) {
+}
+func (b *PeripheralManagerDelegateBase) DidOpenL2CAPChannel(pmgr PeripheralManager, channel L2CAPChannel, err error) {
 }


### PR DESCRIPTION
Add support for L2CAP APIs from CoreBluetooth.

Those APIs were introduced in `macOS 10.13+` so it is still within bounds of the supported APIs described in the README.

---

Context: I'm implementing [OTS](https://www.bluetooth.com/specifications/specs/object-transfer-service-1-0/) which uses L2CAP to transfer objects.

I've added l2cap support here, and used it in a modified version of the bluetooth library and could successfully transfer data over an L2CAP channel.

I will create the pull request to the bluetooth repository once this is merged.

---

Important: I've used Claude through GitHub Copilot to help me create these changes. I've carefully reviewed and understood every piece of produced code. However, I'm not an Objective-C developer, so I don't know if it **misses** something. So far everything looks good and simple to me.