### PR TITLE
feat: add L2CAPChannel Read/Write error

### DIFF
--- a/bt.h
+++ b/bt.h
@@ -137,6 +137,8 @@ void cb_prph_open_l2cap_channel(void *prph, uint16_t psm);
 uint16_t cb_l2cap_psm(void *channel);
 int cb_l2cap_read(void *channel, uint8_t *buf, int maxLen);
 int cb_l2cap_write(void *channel, const uint8_t *data, int len);
+struct bt_error cb_l2cap_input_stream_error(void *channel);
+struct bt_error cb_l2cap_output_stream_error(void *channel);
 bool cb_l2cap_has_bytes_available(void *channel);
 bool cb_l2cap_has_space_available(void *channel);
 void cb_l2cap_schedule_streams(void *channel);

--- a/l2cap.m
+++ b/l2cap.m
@@ -32,6 +32,24 @@ int cb_l2cap_write(void *channel, const uint8_t *data, int len) {
     return (int)[stream write:data maxLength:len];
 }
 
+struct bt_error cb_l2cap_input_stream_error(void *channel) {
+    CBL2CAPChannel *ch = (CBL2CAPChannel *)channel;
+    NSInputStream *stream = ch.inputStream;
+    if (stream.streamStatus == NSStreamStatusError) {
+        return nserror_to_bt_error(stream.streamError);
+    }
+    return (struct bt_error){0};
+}
+
+struct bt_error cb_l2cap_output_stream_error(void *channel) {
+    CBL2CAPChannel *ch = (CBL2CAPChannel *)channel;
+    NSOutputStream *stream = ch.outputStream;
+    if (stream.streamStatus == NSStreamStatusError) {
+        return nserror_to_bt_error(stream.streamError);
+    }
+    return (struct bt_error){0};
+}
+
 bool cb_l2cap_has_bytes_available(void *channel) {
     CBL2CAPChannel *ch = (CBL2CAPChannel *)channel;
     return [ch.inputStream hasBytesAvailable];

--- a/l2capchannel.go
+++ b/l2capchannel.go
@@ -23,22 +23,32 @@ func (ch L2CAPChannel) PSM() uint16 {
 
 // Read reads up to len(buf) bytes from the L2CAP channel's input stream.
 // Returns the number of bytes read. Returns 0 if no bytes are currently
-// available, or a negative value on error.
-func (ch L2CAPChannel) Read(buf []byte) int {
+// available. Returns a negative value and an error on failure.
+func (ch L2CAPChannel) Read(buf []byte) (int, error) {
 	if len(buf) == 0 {
-		return 0
+		return 0, nil
 	}
-	return int(C.cb_l2cap_read(ch.ptr, (*C.uint8_t)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+	n := int(C.cb_l2cap_read(ch.ptr, (*C.uint8_t)(unsafe.Pointer(&buf[0])), C.int(len(buf))))
+	if n < 0 {
+		e := C.cb_l2cap_input_stream_error(ch.ptr)
+		return n, btErrorToNSError(&e)
+	}
+	return n, nil
 }
 
 // Write writes data to the L2CAP channel's output stream.
 // Returns the number of bytes written. Returns 0 if the stream has no space
-// available, or a negative value on error.
-func (ch L2CAPChannel) Write(data []byte) int {
+// available. Returns a negative value and an error on failure.
+func (ch L2CAPChannel) Write(data []byte) (int, error) {
 	if len(data) == 0 {
-		return 0
+		return 0, nil
 	}
-	return int(C.cb_l2cap_write(ch.ptr, (*C.uint8_t)(unsafe.Pointer(&data[0])), C.int(len(data))))
+	n := int(C.cb_l2cap_write(ch.ptr, (*C.uint8_t)(unsafe.Pointer(&data[0])), C.int(len(data))))
+	if n < 0 {
+		e := C.cb_l2cap_output_stream_error(ch.ptr)
+		return n, btErrorToNSError(&e)
+	}
+	return n, nil
 }
 
 // HasBytesAvailable returns true if the input stream has bytes available to read.


### PR DESCRIPTION
When read or write returns -1, we inspect the stream status. If the stream is in Error status, we retrieve the stream error property.

References: 
- https://developer.apple.com/documentation/foundation/stream/streamerror?language=objc 
- https://developer.apple.com/documentation/foundation/stream/streamstatus?language=objc

These changes will also be carried forward to https://github.com/tinygo-org/bluetooth/pull/434 to return a detailed error.

Tested locally with a locally updated version of https://github.com/tinygo-org/bluetooth/pull/434 with the following results:

Before:
```
failed to write object data over L2CAP: failed to write object data to L2CAP channel: bluetooth: L2CAP write error (-1)
```

After:
```
failed to write object data over L2CAP: failed to write object data to L2CAP channel: bluetooth: L2CAP write error: The operation couldn’t be completed. Broken pipe
```